### PR TITLE
fix(guard): 出口 IP 探测改用 Anthropic trace 端点，与 API 流量共用分流策略

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,18 @@
 
 ## Unreleased
 
-- 出口 IP 探测改为默认使用 `api.anthropic.com/cdn-cgi/trace`，回退到
-  `claude.ai/cdn-cgi/trace`，不再默认依赖 `ipinfo.io` / `api.ipify.org`。
-  按规则分流的代理（Clash、Mihomo、Surge 等）依目标域名选择出站策略，第三方查询域名
-  通常落到兜底策略，导致探测到的出口与 Claude 实际使用的出口无关，白名单校验因此
-  失去意义（既可能误拒，也可能漏过真实漂移）。
+- 出口 IP 探测改为默认只使用 `api.anthropic.com/cdn-cgi/trace`，不再默认依赖
+  `ipinfo.io` / `api.ipify.org`。按规则分流的代理（Clash、Mihomo、Surge 等）依目标
+  域名选择出站策略，第三方查询域名通常落到兜底策略，导致探测到的出口与 Claude 实际
+  使用的出口无关，白名单校验因此失去意义（既可能误拒，也可能漏过真实漂移）。
+  默认不配兜底域名：换个 hostname 再问一次不再满足「与 API 流量同策略」这个前提，
+  主端点探不到时的正确行为是 fail-closed。
 - `get_current_ip_once` 同时接受裸 IP 响应体和 `/cdn-cgi/trace` 的 `key=value` 格式，
   用户仍可通过 `CLAUDE_GUARD_IP_CHECK_URLS` 覆盖为任意查询源。
-- 新增 `tests/ip_probe_format.sh`，覆盖两种响应体格式、默认值以及 trace 解析结果
-  不在白名单时仍然 fail-closed。
+- `get_current_ip_once` 不再忽略 curl 的退出状态：curl 因 `--max-time` 超时（退出码
+  28）吐出包含 `ip=` 的部分响应体时不再被采信，改为按探测失败处理。
+- 新增 `tests/ip_probe_format.sh`，覆盖两种响应体格式、默认值、单源默认下不触碰
+  `claude.ai`、curl 部分响应加非零退出，以及 trace 解析结果不在白名单时仍然 fail-closed。
 
 ## 2.0.4 - 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 更完整的版本目标、设计边界和验证说明见 README 的“版本历史”部分。
 
+## Unreleased
+
+- 出口 IP 探测改为默认使用 `api.anthropic.com/cdn-cgi/trace`，回退到
+  `claude.ai/cdn-cgi/trace`，不再默认依赖 `ipinfo.io` / `api.ipify.org`。
+  按规则分流的代理（Clash、Mihomo、Surge 等）依目标域名选择出站策略，第三方查询域名
+  通常落到兜底策略，导致探测到的出口与 Claude 实际使用的出口无关，白名单校验因此
+  失去意义（既可能误拒，也可能漏过真实漂移）。
+- `get_current_ip_once` 同时接受裸 IP 响应体和 `/cdn-cgi/trace` 的 `key=value` 格式，
+  用户仍可通过 `CLAUDE_GUARD_IP_CHECK_URLS` 覆盖为任意查询源。
+- 新增 `tests/ip_probe_format.sh`，覆盖两种响应体格式、默认值以及 trace 解析结果
+  不在白名单时仍然 fail-closed。
+
 ## 2.0.4 - 2026-08-01
 
 - 新增离线 `status`，显示总体健康、活动 Claude 会话、watchdog 覆盖、PID 状态、

--- a/README.md
+++ b/README.md
@@ -476,6 +476,15 @@ cp config/safe-claude.example.json ~/.safe-claude-official.json
 
 `203.0.113.0/24` 是文档示例网段。实际使用时请替换成你自己的固定出口 IP 或 CIDR。
 
+出口探测默认打 `api.anthropic.com/cdn-cgi/trace`，而不是第三方 IP 查询服务。原因是
+Clash、Mihomo、Surge 这类按规则分流的代理会依据目标域名选择出站策略：如果探测打的是
+`ipinfo.io`，它很可能落到兜底策略，量到的是另一条线路的出口，和 Claude 实际使用的出口
+无关。用 Anthropic 自己的域名探测，可以保证探测流量与 API 流量命中同一条分流规则。
+
+如果要换回第三方查询源，`CLAUDE_GUARD_IP_CHECK_URLS` 同时支持裸 IP 响应体和
+`/cdn-cgi/trace` 的 `key=value` 格式；但请自行确认该域名在你的代理配置里与
+`api.anthropic.com` 走同一条策略，否则白名单校验的是错误链路。
+
 客户端身份字段是可选的，但安全入口建议全部填写。更新 Claude Code 时应先离线核对新版本、哈希和签名，再一起更新配置；`v2.0.0` 会把不匹配视为失败，不会静默运行新二进制。
 
 `blocked_models` 只用于阻止你明确知道不能进入官方通道的本地 alias。保持空数组
@@ -584,7 +593,7 @@ claude-cc --launcher-version
 CLAUDE_GUARD_CONFIG=~/.safe-claude-official.json
 CLAUDE_GUARD_SETTINGS=~/.claude-official/settings.json
 CLAUDE_GUARD_PROXY=http://127.0.0.1:7897
-CLAUDE_GUARD_IP_CHECK_URLS="https://ipinfo.io/ip https://api.ipify.org"
+CLAUDE_GUARD_IP_CHECK_URLS="https://api.anthropic.com/cdn-cgi/trace https://claude.ai/cdn-cgi/trace"
 CLAUDE_GUARD_ASSUME_YES=1
 CLAUDE_GUARD_WATCHDOG=1
 CLAUDE_GUARD_WATCHDOG_DRY_RUN=1

--- a/README.md
+++ b/README.md
@@ -476,13 +476,18 @@ cp config/safe-claude.example.json ~/.safe-claude-official.json
 
 `203.0.113.0/24` 是文档示例网段。实际使用时请替换成你自己的固定出口 IP 或 CIDR。
 
-出口探测默认打 `api.anthropic.com/cdn-cgi/trace`，而不是第三方 IP 查询服务。原因是
+出口探测默认只打 `api.anthropic.com/cdn-cgi/trace`，而不是第三方 IP 查询服务。原因是
 Clash、Mihomo、Surge 这类按规则分流的代理会依据目标域名选择出站策略：如果探测打的是
 `ipinfo.io`，它很可能落到兜底策略，量到的是另一条线路的出口，和 Claude 实际使用的出口
-无关。用 Anthropic 自己的域名探测，可以保证探测流量与 API 流量命中同一条分流规则。
+无关。打 API 自己的域名，探测流量与 API 流量命中同一条分流策略（在固定／黏性出口下即
+同一出口；策略组是 url-test 或负载均衡时，同一条策略的两次请求仍可能出不同 IP）。
 
-如果要换回第三方查询源，`CLAUDE_GUARD_IP_CHECK_URLS` 同时支持裸 IP 响应体和
-`/cdn-cgi/trace` 的 `key=value` 格式；但请自行确认该域名在你的代理配置里与
+默认不配任何兜底域名。换一个 hostname 再问一次就不再满足「与 API 流量同策略」这个前提，
+拿一条不确定链路的出口去判定白名单，正是这里要避免的问题；主端点探不到时的正确行为是
+fail-closed（退出码 3）。
+
+如果要换回第三方查询源或自行添加兜底，`CLAUDE_GUARD_IP_CHECK_URLS` 同时支持裸 IP 响应体
+和 `/cdn-cgi/trace` 的 `key=value` 格式；但请自行确认这些域名在你的代理配置里与
 `api.anthropic.com` 走同一条策略，否则白名单校验的是错误链路。
 
 客户端身份字段是可选的，但安全入口建议全部填写。更新 Claude Code 时应先离线核对新版本、哈希和签名，再一起更新配置；`v2.0.0` 会把不匹配视为失败，不会静默运行新二进制。
@@ -593,7 +598,7 @@ claude-cc --launcher-version
 CLAUDE_GUARD_CONFIG=~/.safe-claude-official.json
 CLAUDE_GUARD_SETTINGS=~/.claude-official/settings.json
 CLAUDE_GUARD_PROXY=http://127.0.0.1:7897
-CLAUDE_GUARD_IP_CHECK_URLS="https://api.anthropic.com/cdn-cgi/trace https://claude.ai/cdn-cgi/trace"
+CLAUDE_GUARD_IP_CHECK_URLS="https://api.anthropic.com/cdn-cgi/trace"
 CLAUDE_GUARD_ASSUME_YES=1
 CLAUDE_GUARD_WATCHDOG=1
 CLAUDE_GUARD_WATCHDOG_DRY_RUN=1

--- a/bin/claude-guard
+++ b/bin/claude-guard
@@ -11,7 +11,7 @@ CA_CERT_FILE="${CLAUDE_GUARD_CA_CERT:-/etc/ssl/cert.pem}"
 CLAUDE_PROXY_URL="${CLAUDE_GUARD_PROXY:-${CLAUDE_OFFICIAL_PROXY:-http://127.0.0.1:7897}}"
 NO_PROXY_LIST="${CLAUDE_GUARD_NO_PROXY:-${CLAUDE_OFFICIAL_NO_PROXY:-127.0.0.1,localhost,::1,.local}}"
 IP_CHECK_RETRIES="${CLAUDE_GUARD_IP_RETRIES:-${CLAUDE_OFFICIAL_IP_RETRIES:-3}}"
-IP_CHECK_URLS="${CLAUDE_GUARD_IP_CHECK_URLS:-${CLAUDE_OFFICIAL_IP_CHECK_URLS:-https://api.anthropic.com/cdn-cgi/trace https://claude.ai/cdn-cgi/trace}}"
+IP_CHECK_URLS="${CLAUDE_GUARD_IP_CHECK_URLS:-${CLAUDE_OFFICIAL_IP_CHECK_URLS:-https://api.anthropic.com/cdn-cgi/trace}}"
 TLS_CHECK_RETRIES="${CLAUDE_GUARD_TLS_RETRIES:-${CLAUDE_OFFICIAL_TLS_RETRIES:-3}}"
 PLATFORM_TLS_MODE="${CLAUDE_GUARD_PLATFORM_TLS_MODE:-${CLAUDE_OFFICIAL_PLATFORM_TLS_MODE:-warn}}"
 ASSUME_YES="${CLAUDE_GUARD_ASSUME_YES:-0}"
@@ -79,7 +79,9 @@ Environment:
   CLAUDE_GUARD_PROXY         Required proxy URL. Default: http://127.0.0.1:7897
   CLAUDE_GUARD_NO_PROXY      NO_PROXY list. Default: 127.0.0.1,localhost,::1,.local
   CLAUDE_GUARD_ASSUME_YES    Set to 1 to skip the final Enter prompt when IP is allowed.
-  CLAUDE_GUARD_IP_CHECK_URLS Space-separated IPv4 echo endpoints.
+  CLAUDE_GUARD_IP_CHECK_URLS Space-separated egress probe endpoints. Both bare-IP
+                             and /cdn-cgi/trace response bodies are accepted.
+                             Default: https://api.anthropic.com/cdn-cgi/trace
   CLAUDE_GUARD_UI             auto, always, or never. Default: auto.
                               auto renders the visual preflight only in an interactive terminal.
   NO_COLOR                   Disable ANSI colors while keeping the visual preflight layout.
@@ -1436,7 +1438,12 @@ get_current_ip_once() {
   local url ip raw
 
   for url in $IP_CHECK_URLS; do
-    raw="$(official_net_env curl -4 -x "$CLAUDE_PROXY_URL" -fsS --connect-timeout 5 --max-time 10 "$url" 2>/dev/null || true)"
+    # curl 非零退出时一律丢弃响应体。--max-time 超时（退出码 28）等情况下 curl 可能
+    # 已经吐出包含完整 ip= 字段的部分响应，采信它等于拿一个来路不明的截断结果去判定
+    # 白名单；此处宁可探测失败，交给外层重试与 exit 3 处理。
+    if ! raw="$(official_net_env curl -4 -x "$CLAUDE_PROXY_URL" -fsS --connect-timeout 5 --max-time 10 "$url" 2>/dev/null)"; then
+      continue
+    fi
 
     # 裸 IP 响应体，例如 https://api.ipify.org。
     ip="$(printf '%s' "$raw" | tr -d '[:space:]')"

--- a/bin/claude-guard
+++ b/bin/claude-guard
@@ -11,7 +11,7 @@ CA_CERT_FILE="${CLAUDE_GUARD_CA_CERT:-/etc/ssl/cert.pem}"
 CLAUDE_PROXY_URL="${CLAUDE_GUARD_PROXY:-${CLAUDE_OFFICIAL_PROXY:-http://127.0.0.1:7897}}"
 NO_PROXY_LIST="${CLAUDE_GUARD_NO_PROXY:-${CLAUDE_OFFICIAL_NO_PROXY:-127.0.0.1,localhost,::1,.local}}"
 IP_CHECK_RETRIES="${CLAUDE_GUARD_IP_RETRIES:-${CLAUDE_OFFICIAL_IP_RETRIES:-3}}"
-IP_CHECK_URLS="${CLAUDE_GUARD_IP_CHECK_URLS:-${CLAUDE_OFFICIAL_IP_CHECK_URLS:-https://ipinfo.io/ip https://api.ipify.org}}"
+IP_CHECK_URLS="${CLAUDE_GUARD_IP_CHECK_URLS:-${CLAUDE_OFFICIAL_IP_CHECK_URLS:-https://api.anthropic.com/cdn-cgi/trace https://claude.ai/cdn-cgi/trace}}"
 TLS_CHECK_RETRIES="${CLAUDE_GUARD_TLS_RETRIES:-${CLAUDE_OFFICIAL_TLS_RETRIES:-3}}"
 PLATFORM_TLS_MODE="${CLAUDE_GUARD_PLATFORM_TLS_MODE:-${CLAUDE_OFFICIAL_PLATFORM_TLS_MODE:-warn}}"
 ASSUME_YES="${CLAUDE_GUARD_ASSUME_YES:-0}"
@@ -1433,10 +1433,20 @@ cidr_contains_ip() {
 }
 
 get_current_ip_once() {
-  local url ip
+  local url ip raw
 
   for url in $IP_CHECK_URLS; do
-    ip="$(official_net_env curl -4 -x "$CLAUDE_PROXY_URL" -fsS --connect-timeout 5 --max-time 10 "$url" 2>/dev/null | tr -d '[:space:]' || true)"
+    raw="$(official_net_env curl -4 -x "$CLAUDE_PROXY_URL" -fsS --connect-timeout 5 --max-time 10 "$url" 2>/dev/null || true)"
+
+    # 裸 IP 响应体，例如 https://api.ipify.org。
+    ip="$(printf '%s' "$raw" | tr -d '[:space:]')"
+    if is_ipv4 "$ip"; then
+      printf '%s\n' "$ip"
+      return 0
+    fi
+
+    # Cloudflare /cdn-cgi/trace 响应体：形如 ip=203.0.113.10 的 key=value 多行文本。
+    ip="$(printf '%s\n' "$raw" | awk -F= '/^ip=/ { print $2; exit }' | tr -d '[:space:]')"
     if is_ipv4 "$ip"; then
       printf '%s\n' "$ip"
       return 0

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 "$ROOT_DIR/tests/smoke.sh"
+"$ROOT_DIR/tests/ip_probe_format.sh"
 "$ROOT_DIR/tests/preflight_ui.sh"
 "$ROOT_DIR/tests/watchdog_state_machine.sh"
 "$ROOT_DIR/tests/watchdog_runtime.sh"

--- a/tests/ip_probe_format.sh
+++ b/tests/ip_probe_format.sh
@@ -88,7 +88,7 @@ run_precheck() {
     cd "$TMP_DIR"
     HOME="$TMP_DIR/home" \
       USER="guard-test" \
-      PATH="$TMP_DIR/bin:$PATH" \
+      PATH="${3:-$TMP_DIR/bin}:$PATH" \
       LANG="en_US.UTF-8" \
       CLAUDE_GUARD_CONFIG="$1" \
       CLAUDE_GUARD_IP_CHECK_URLS="$2" \
@@ -124,5 +124,120 @@ if [ "$status" -ne 4 ]; then
   exit 1
 fi
 grep -q 'IP 检查失败：203.0.113.10' "$TMP_DIR/denied.out"
+
+# 5. 默认配置下主端点探测失败必须 fail-closed（exit 3），且全程不得请求 claude.ai。
+#    默认值是单源的：换个 hostname 再问一次就不再与 API 流量同策略，等于用一条不确定
+#    的链路去判定白名单。用户把两个域名都写进 CLAUDE_GUARD_IP_CHECK_URLS 是主动选择，
+#    不在本用例射程内。
+mkdir -p "$TMP_DIR/bin-trace-fail"
+cat >"$TMP_DIR/bin-trace-fail/curl" <<'EOF'
+#!/usr/bin/env bash
+args="$*"
+printf '%s\n' "$args" >>"$HOME/trace-fail-curl.log"
+
+if printf '%s' "$args" | grep -Eq '(^| )-6( |$)'; then
+  exit 7
+fi
+
+# 主端点探测失败：解析不到主机，无响应体。
+if printf '%s' "$args" | grep -q '/cdn-cgi/trace'; then
+  exit 6
+fi
+
+if printf '%s' "$args" | grep -q 'https://api.anthropic.com/'; then
+  {
+    printf '* CONNECT api.anthropic.com:443 HTTP/1.1\n'
+    printf '* CONNECT tunnel established\n'
+    printf '* SSL certificate verify ok.\n'
+    printf '*  issuer: C=US; O=Google Trust Services; CN=WE1\n'
+  } >&2
+  exit 0
+fi
+
+if printf '%s' "$args" | grep -q 'https://platform.claude.com/'; then
+  {
+    printf '* CONNECT platform.claude.com:443 HTTP/1.1\n'
+    printf '* CONNECT tunnel established\n'
+    printf '* SSL certificate verify ok.\n'
+    printf '*  issuer: C=US; O=Let'\''s Encrypt; CN=YE1\n'
+  } >&2
+  exit 0
+fi
+
+exit 1
+EOF
+chmod +x "$TMP_DIR/bin-trace-fail/curl"
+
+: >"$TMP_DIR/home/trace-fail-curl.log"
+set +e
+run_precheck "$TMP_DIR/allowed.json" "" "$TMP_DIR/bin-trace-fail" >"$TMP_DIR/trace_fail.out" 2>&1
+status=$?
+set -e
+if [ "$status" -ne 3 ]; then
+  printf 'default-URL trace failure returned %s instead of 3\n' "$status" >&2
+  cat "$TMP_DIR/trace_fail.out" >&2
+  exit 1
+fi
+grep -q 'IP 检查失败：无法获取当前出口 IP' "$TMP_DIR/trace_fail.out"
+if grep -q 'claude\.ai' "$TMP_DIR/home/trace-fail-curl.log"; then
+  printf 'default URL list must not fall back to claude.ai\n' >&2
+  cat "$TMP_DIR/home/trace-fail-curl.log" >&2
+  exit 1
+fi
+
+# 6. curl 吐出部分响应体后以 28（--max-time 超时）退出时不得采信该响应体。
+#    这里白名单里正好有部分响应中的那个 IP：一旦采信就会 exit 0 放行，因此本用例
+#    要求 exit 3。
+mkdir -p "$TMP_DIR/bin-partial"
+cat >"$TMP_DIR/bin-partial/curl" <<'EOF'
+#!/usr/bin/env bash
+args="$*"
+
+if printf '%s' "$args" | grep -Eq '(^| )-6( |$)'; then
+  exit 7
+fi
+
+# 超时中断：响应体已经包含完整的 ip= 字段，但 curl 以 28 退出。
+if printf '%s' "$args" | grep -q '/cdn-cgi/trace'; then
+  printf 'fl=1f2\n'
+  printf 'h=api.anthropic.com\n'
+  printf 'ip=203.0.113.10\n'
+  exit 28
+fi
+
+if printf '%s' "$args" | grep -q 'https://api.anthropic.com/'; then
+  {
+    printf '* CONNECT api.anthropic.com:443 HTTP/1.1\n'
+    printf '* CONNECT tunnel established\n'
+    printf '* SSL certificate verify ok.\n'
+    printf '*  issuer: C=US; O=Google Trust Services; CN=WE1\n'
+  } >&2
+  exit 0
+fi
+
+if printf '%s' "$args" | grep -q 'https://platform.claude.com/'; then
+  {
+    printf '* CONNECT platform.claude.com:443 HTTP/1.1\n'
+    printf '* CONNECT tunnel established\n'
+    printf '* SSL certificate verify ok.\n'
+    printf '*  issuer: C=US; O=Let'\''s Encrypt; CN=YE1\n'
+  } >&2
+  exit 0
+fi
+
+exit 1
+EOF
+chmod +x "$TMP_DIR/bin-partial/curl"
+
+set +e
+run_precheck "$TMP_DIR/allowed.json" "" "$TMP_DIR/bin-partial" >"$TMP_DIR/partial.out" 2>&1
+status=$?
+set -e
+if [ "$status" -ne 3 ]; then
+  printf 'partial body with curl exit 28 returned %s instead of 3\n' "$status" >&2
+  cat "$TMP_DIR/partial.out" >&2
+  exit 1
+fi
+grep -q 'IP 检查失败：无法获取当前出口 IP' "$TMP_DIR/partial.out"
 
 printf 'ip probe format ok\n'

--- a/tests/ip_probe_format.sh
+++ b/tests/ip_probe_format.sh
@@ -7,6 +7,10 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 mkdir -p "$TMP_DIR/bin" "$TMP_DIR/home"
 
+# 出口探测的两种响应体格式：
+#   - 裸 IP：https://api.ipify.org
+#   - Cloudflare /cdn-cgi/trace：key=value 多行文本
+# trace 分支必须排在 api.anthropic.com 的 TLS 分支之前，否则会被后者吞掉。
 cat >"$TMP_DIR/bin/curl" <<'EOF'
 #!/usr/bin/env bash
 args="$*"
@@ -16,7 +20,11 @@ if printf '%s' "$args" | grep -Eq '(^| )-6( |$)'; then
 fi
 
 if printf '%s' "$args" | grep -q '/cdn-cgi/trace'; then
-  printf 'h=api.anthropic.com\nip=203.0.113.10\nvisit_scheme=https\n'
+  printf 'fl=1f2\n'
+  printf 'h=api.anthropic.com\n'
+  printf 'ip=203.0.113.10\n'
+  printf 'ts=1700000000.000\n'
+  printf 'visit_scheme=https\n'
   exit 0
 fi
 
@@ -36,10 +44,6 @@ if printf '%s' "$args" | grep -q 'https://api.anthropic.com/'; then
 fi
 
 if printf '%s' "$args" | grep -q 'https://platform.claude.com/'; then
-  if [ -f "$HOME/fail-platform-tls" ]; then
-    printf 'curl: (35) simulated TLS connection error\n' >&2
-    exit 35
-  fi
   {
     printf '* CONNECT platform.claude.com:443 HTTP/1.1\n'
     printf '* CONNECT tunnel established\n'
@@ -87,81 +91,38 @@ run_precheck() {
       PATH="$TMP_DIR/bin:$PATH" \
       LANG="en_US.UTF-8" \
       CLAUDE_GUARD_CONFIG="$1" \
+      CLAUDE_GUARD_IP_CHECK_URLS="$2" \
       CLAUDE_GUARD_SETTINGS="$TMP_DIR/settings.json" \
       CLAUDE_GUARD_CA_CERT="$TMP_DIR/cert.pem" \
       CLAUDE_GUARD_IP_RETRIES=1 \
       CLAUDE_GUARD_TLS_RETRIES=1 \
-      CLAUDE_GUARD_UI="$2" \
+      CLAUDE_GUARD_UI=never \
       "$ROOT_DIR/bin/claude-guard" --precheck-only
   )
 }
 
-if [ "${CLAUDE_GUARD_TEST_LIVE:-0}" = "1" ]; then
-  run_precheck "$TMP_DIR/allowed.json" auto
-  exit 0
-fi
+# 1. /cdn-cgi/trace 响应体可解析出出口 IP。
+run_precheck "$TMP_DIR/allowed.json" "https://api.anthropic.com/cdn-cgi/trace" >"$TMP_DIR/trace.out" 2>&1
+grep -q 'IP 检查通过：203.0.113.10' "$TMP_DIR/trace.out"
 
-run_precheck "$TMP_DIR/allowed.json" always >"$TMP_DIR/ui.out" 2>&1
-grep -q 'Claude Guard · Official Preflight' "$TMP_DIR/ui.out"
-grep -q '✓' "$TMP_DIR/ui.out"
-grep -q '8/8' "$TMP_DIR/ui.out"
-grep -q '预检已通过' "$TMP_DIR/ui.out"
-grep -q 'IP 检查通过：203.0.113.10' "$TMP_DIR/ui.out"
-
-run_precheck "$TMP_DIR/allowed.json" never >"$TMP_DIR/plain.out" 2>&1
-if grep -q 'Claude Guard · Official Preflight' "$TMP_DIR/plain.out"; then
-  printf 'plain UI mode unexpectedly rendered the visual preflight\n' >&2
-  exit 1
-fi
+# 2. 裸 IP 响应体仍然可解析（向后兼容，用户可继续覆盖为第三方查询源）。
+run_precheck "$TMP_DIR/allowed.json" "https://api.ipify.org" >"$TMP_DIR/plain.out" 2>&1
 grep -q 'IP 检查通过：203.0.113.10' "$TMP_DIR/plain.out"
-grep -q '预检完成：未启动 Claude。' "$TMP_DIR/plain.out"
-if grep -q '出口 IP 已获取' "$TMP_DIR/plain.out"; then
-  printf 'plain UI mode changed the legacy output contract\n' >&2
-  exit 1
-fi
 
-run_precheck "$TMP_DIR/allowed.json" auto >"$TMP_DIR/auto.out" 2>&1
-if grep -q 'Official Preflight' "$TMP_DIR/auto.out"; then
-  printf 'auto UI mode rendered visual output without a TTY\n' >&2
-  exit 1
-fi
-grep -q '预检完成：未启动 Claude。' "$TMP_DIR/auto.out"
+# 3. 默认值走 trace 端点，与 API 流量共用代理分流策略。
+run_precheck "$TMP_DIR/allowed.json" "" >"$TMP_DIR/default.out" 2>&1
+grep -q 'IP 检查通过：203.0.113.10' "$TMP_DIR/default.out"
 
-NO_COLOR=1 run_precheck "$TMP_DIR/allowed.json" always >"$TMP_DIR/no-color.out" 2>&1
-if LC_ALL=C grep -q "$(printf '\033')" "$TMP_DIR/no-color.out"; then
-  printf 'NO_COLOR output contains ANSI escape sequences\n' >&2
-  exit 1
-fi
-grep -q 'Claude Guard · Official Preflight' "$TMP_DIR/no-color.out"
-
-touch "$TMP_DIR/home/fail-platform-tls"
-run_precheck "$TMP_DIR/allowed.json" always >"$TMP_DIR/warn.out" 2>&1
-rm "$TMP_DIR/home/fail-platform-tls"
-grep -q 'TLS 预检警告：platform.claude.com' "$TMP_DIR/warn.out"
-grep -q '含 1 条警告' "$TMP_DIR/warn.out"
-grep -q '预检已通过' "$TMP_DIR/warn.out"
-
+# 4. trace 解析出的 IP 不在白名单时仍然 fail-closed。
 set +e
-run_precheck "$TMP_DIR/denied.json" always >"$TMP_DIR/denied.out" 2>&1
+run_precheck "$TMP_DIR/denied.json" "https://api.anthropic.com/cdn-cgi/trace" >"$TMP_DIR/denied.out" 2>&1
 status=$?
 set -e
 if [ "$status" -ne 4 ]; then
-  printf 'visual denied-IP test returned %s instead of 4\n' "$status" >&2
+  printf 'trace denied-IP test returned %s instead of 4\n' "$status" >&2
   cat "$TMP_DIR/denied.out" >&2
   exit 1
 fi
 grep -q 'IP 检查失败：203.0.113.10' "$TMP_DIR/denied.out"
-grep -q '预检未通过' "$TMP_DIR/denied.out"
-if grep -q '预检已通过' "$TMP_DIR/denied.out"; then
-  printf 'visual denied-IP test rendered a false success state\n' >&2
-  exit 1
-fi
 
-if [ "${CLAUDE_GUARD_TEST_DUMP:-0}" = "1" ]; then
-  printf '%s\n' '--- visual pass ---'
-  cat "$TMP_DIR/ui.out"
-  printf '%s\n' '--- visual fail ---'
-  cat "$TMP_DIR/denied.out"
-fi
-
-printf 'preflight ui ok\n'
+printf 'ip probe format ok\n'

--- a/tests/lifecycle_policy.sh
+++ b/tests/lifecycle_policy.sh
@@ -37,6 +37,10 @@ args="$*"
 if printf '%s' "$args" | grep -Eq '(^| )-6( |$)'; then
   exit 7
 fi
+if printf '%s' "$args" | grep -q '/cdn-cgi/trace'; then
+  printf 'h=api.anthropic.com\nip=203.0.113.10\nvisit_scheme=https\n'
+  exit 0
+fi
 if printf '%s' "$args" | grep -Eq 'https://(ipinfo.io/ip|api.ipify.org)'; then
   printf '203.0.113.10\n'
   exit 0

--- a/tests/v2_upgrade_policy.sh
+++ b/tests/v2_upgrade_policy.sh
@@ -32,6 +32,12 @@ args="$*"
 if printf '%s' "$args" | grep -Eq '(^| )-6( |$)'; then
   exit 7
 fi
+if printf '%s' "$args" | grep -q '/cdn-cgi/trace'; then
+  printf 'h=api.anthropic.com\n'
+  printf 'ip=%s\n' "${FAKE_EXIT_IP:-203.0.113.10}"
+  printf 'visit_scheme=https\n'
+  exit 0
+fi
 if printf '%s' "$args" | grep -Eq 'https://(ipinfo.io/ip|api.ipify.org)'; then
   printf '%s\n' "${FAKE_EXIT_IP:-203.0.113.10}"
   exit 0


### PR DESCRIPTION
## 问题

出口 IP 探测和 Anthropic API 流量走的不是同一条代理分流策略，导致 `allowed_ips` 校验的是错误链路。

`get_current_ip_once` 默认探测 `ipinfo.io` 和 `api.ipify.org`。但 Clash、Mihomo、Surge 这类代理是**按目标域名**选择出站策略的——用户的配置里通常只为 `anthropic.com` / `claude.ai` 指定了策略，第三方 IP 查询域名不在规则内，会落到兜底策略（`FINAL` / 漏网之鱼）。

于是探测量到的是兜底线路的出口，而 Claude 实际用的是 Anthropic 规则指定的节点。两者可以完全无关。

实测（Surge，`DOMAIN-SUFFIX,anthropic.com` 指向一个固定 IP 节点）：

```
curl -x <proxy> https://ipinfo.io/ip                      -> 兜底策略的出口
curl -x <proxy> https://api.anthropic.com/cdn-cgi/trace   -> ip=<Anthropic 规则节点的出口>
```

两个值不同。后者才是 Claude 真正的出口。

这让门禁在两个方向上都失效：

- **误拒**：白名单填真实出口 → 探测量到兜底出口 → 不匹配 → fail-closed 拒绝启动，用户被挡在门外而配置其实是对的
- **漏过**：白名单填探测出口 → Anthropic 那条线路真的漂移了 → 探测毫无反应

第二种更糟——出口漂移检测正是这个功能存在的理由。

注意这不是某个代理软件的特例。项目默认代理端口 `7897` 就是 Clash 的，而 Clash 同样按规则分流，所以核心用户群大概率都在这个问题里。

## 改动

**默认探测地址改为 `api.anthropic.com/cdn-cgi/trace`，且只有这一个。**

这个域名必然命中用户已有的 Anthropic 分流规则——不需要用户新增任何代理规则，探测流量与 API 流量天然同策略。附带好处是去掉了对第三方 IP 查询服务的默认依赖。

**默认不配任何兜底域名。** 初版留了 `claude.ai/cdn-cgi/trace` 作为回退，复审时被否掉了，理由成立：这条 PR 的前提是探测必须与 API 流量命中同一条分流策略，而 `claude.ai` 是另一个 hostname，认证域名和 API 域名在规则里分开配是常见做法，它完全可能走另一条策略。换个域名再问一次，等于退回到本 PR 想解决的那个问题。主端点探不到时的正确行为是 fail-closed（退出码 3），交给现有的重试逻辑处理。想保留任何兜底的用户可以自己写进 `CLAUDE_GUARD_IP_CHECK_URLS`，这条路径没动。

同理也**没有**保留 `ipinfo.io`。

**`get_current_ip_once` 同时接受两种响应体格式**：裸 IP，以及 `/cdn-cgi/trace` 的 `key=value` 多行文本。`CLAUDE_GUARD_IP_CHECK_URLS` 覆盖行为不变，用户想换回任何第三方查询源都可以，向后兼容。

**`get_current_ip_once` 先判定 curl 成功，再解析响应体。** 原先的 `|| true` 会抹掉 curl 的退出码：curl 因 `--max-time` 超时（退出码 28）但已吐出包含完整 `ip=` 字段的部分响应时，这段会当成功结果接受。这个写法是从旧代码继承的，但旧默认值下截断的裸 IP 大概率过不了 `is_ipv4`，trace 格式下部分响应可能已经包含完整的 `ip=`，暴露面更大，所以这次一并收掉。

## 测试

新增 `tests/ip_probe_format.sh`，覆盖：

1. trace 响应体能解析出出口 IP
2. 裸 IP 响应体仍可解析（向后兼容）
3. 默认值走 trace 端点
4. trace 解析出的 IP 不在白名单时仍然 fail-closed（退出码 4）
5. **默认配置下 trace 探测失败必须退出码 3，并断言全程没有请求过 `claude.ai`**（用例记录每一次假 curl 的调用参数再断言）
6. **curl 输出 partial body 后以 28 退出时必须退出码 3**（用例的白名单里正好有部分响应中的那个 IP，一旦采信就会 exit 0 放行，所以这条断言是紧的）

5 和 6 都反向验证过：分别把对应改动回退掉之后，用例确实失败（`default URL list must not fall back to claude.ai` / `partial body with curl exit 28 returned 0 instead of 3`）。

`tests/preflight_ui.sh`、`tests/lifecycle_policy.sh`、`tests/v2_upgrade_policy.sh` 的假 curl 依赖旧默认值，同步补上 trace 分支（放在 `api.anthropic.com` 的 TLS 分支之前，否则会被吞掉）。`smoke.sh` 和 `visibility.sh` 显式设置了 `CLAUDE_GUARD_IP_CHECK_URLS`，未受影响。

`./scripts/check.sh` 全绿（9 个 fixture）。依赖仍然只有 bash / curl / jq，新增解析用的是 `awk`，与既有代码一致。

## 边界

不涉及 TLS MITM、请求体改写、base URL 改写、凭据处理，也不涉及任何反检测行为。只是把探测打到正确的域名上。

README 的环境变量示例和 `allowed_ips` 章节已同步说明原因，其中「命中同一条分流规则」按复审意见收敛为「命中同一条分流策略（固定／黏性出口下即同一出口）」，并补了默认为什么不配兜底域名。`bin/claude-guard --help` 里 `CLAUDE_GUARD_IP_CHECK_URLS` 的描述也一并改准确并写明默认值。

CHANGELOG 只修正了本 PR 已添加的 Unreleased 条目中现在不再成立的表述（`claude.ai` 兜底），封版说明按你说的留给发版时统一处理。

