### PR TITLE
fix(guard): Schannel 后端的 TLS 预检改为明确报平台不兼容

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@
   28）吐出包含 `ip=` 的部分响应体时不再被采信，改为按探测失败处理。
 - 新增 `tests/ip_probe_format.sh`，覆盖两种响应体格式、默认值、单源默认下不触碰
   `claude.ai`、curl 部分响应加非零退出，以及 trace 解析结果不在白名单时仍然 fail-closed。
+- TLS 预检遇到 Schannel（Windows 原生）后端的 curl 时，报错改为明确指出平台不兼容，
+  跳过无意义的重试，并且不再谎报尝试次数。后端识别先于 curl 退出码判定——Schannel 在
+  证书校验失败时同样会以非零码退出，那时报「无法连接或验证证书」会把平台限制说成网络
+  或代理问题。Schannel 不输出证书验证结果和 issuer，`check_tls_host` 的 MITM 检测无法
+  执行；**不做静默降级**，放宽匹配只会把这一步变成什么都不查的空步骤。
+- README 新增「平台支持」一节：macOS 已验证，Linux 需自行设置 `CLAUDE_GUARD_CA_CERT`
+  （默认值 `/etc/ssl/cert.pem` 是 macOS 路径），Windows 原生不支持并给出两条绕行方案。
+- 新增 `tests/tls_backend_platform.sh`，覆盖 Schannel 在 curl 退出码 0 和 60 两种形态下
+  的行为：退出码仍是 7、报错指名后端、不回落到含糊文案、不重试、不声称重试过。fixture
+  直接复用 `config/official-settings-lifecycle.example.json`，生命周期策略升级时不会过期。
 
 ## 2.0.4 - 2026-08-01
 

--- a/README.md
+++ b/README.md
@@ -406,6 +406,39 @@ watchdog 或 Claude Code 启动参数。
 - 不管理 Claude Code 进程生命周期。
 - 不替代用户的代理、VPN 或 Clash/Mihomo 配置。
 
+## 平台支持
+
+| 平台 | 状态 | 说明 |
+| --- | --- | --- |
+| macOS | 已验证 | 开发与回归测试环境 |
+| Linux | 预期可用 | 需要把 `CLAUDE_GUARD_CA_CERT` 指向本机 CA bundle，默认值 `/etc/ssl/cert.pem` 是 macOS 路径 |
+| Windows（原生） | 不支持 | 见下 |
+
+Windows 原生 curl（以及任何使用 Schannel TLS 后端的 curl）跑不了启动门禁的 TLS 检查。
+原因不是某个字符串没匹配上：`check_tls_host` 要从 curl 的 verbose 输出里读出证书的
+`issuer:`，再拿它匹配 Charles、Fiddler、Zscaler 这类 MITM 特征——TLS 预检存在的理由就是
+这个检查。Schannel 既不打印 `SSL certificate verify ok`，也不打印 `issuer:`，所以放宽匹配
+并不能恢复检查，只会把这一步变成什么都不查的空步骤。因此这里选择明确报错，不做静默降级。
+
+判断方法：`curl -V`，第一行末尾会写 SSL 后端。如果是 `Schannel`，有两条路：
+
+**1）改用 OpenSSL 编译的 curl。** MSYS2 的 `mingw-w64-x86_64-curl`，或确认 PATH 里
+Git for Windows 的 `mingw64\bin\curl.exe` 排在 `C:\Windows\System32\curl.exe` 前面。
+注意换完还有一个坑：Schannel 会忽略 `SSL_CERT_FILE`，换成 OpenSSL 后它就生效了，因此需要
+设 `CLAUDE_GUARD_CA_CERT` 指向真实 CA bundle，Git for Windows 一般在
+`C:\Program Files\Git\mingw64\etc\ssl\certs\ca-bundle.crt`。
+
+**2）用 WSL2。** 两处要额外配：
+
+- 代理：WSL2 有独立网络命名空间，里面的 `127.0.0.1:7897` 不是 Windows 上的 Clash。
+  要么在 `.wslconfig` 里开 `networkingMode=mirrored`（Windows 11），要么在 Clash 开
+  「允许局域网连接」后设
+  `CLAUDE_GUARD_PROXY=http://$(ip route show default | awk '{print $3}'):7897`。
+- CA：`CLAUDE_GUARD_CA_CERT=/etc/ssl/certs/ca-certificates.crt`。
+
+两条路都不要在安全配置里填 `client_macos_team_id`——签名校验走 macOS `codesign`，
+在非 Darwin 平台会直接判失败。
+
 ## 安装
 
 ```bash

--- a/bin/claude-guard
+++ b/bin/claude-guard
@@ -746,38 +746,55 @@ check_model_policy() {
   done
 }
 
+# Schannel（Windows 原生 TLS 后端）既不打印 "SSL certificate verify ok"，也不打印证书
+# issuer，下面基于 curl verbose 输出的证书检查在它上面无法执行。放宽字符串匹配并不能
+# 恢复检查，只会把这一步变成什么都不查的空步骤，因此直接判定为平台不支持。
+tls_backend_lacks_cert_details() {
+  printf '%s\n' "$1" | grep -qi '^\* schannel'
+}
+
 check_tls_host() {
   local host="$1"
   local mode="${2:-required}"
-  local out issuer reason attempt
+  local out issuer reason attempt unsupported curl_status
 
   attempt=1
+  unsupported=0
   while [ "$attempt" -le "$TLS_CHECK_RETRIES" ]; do
     reason=''
-    if out="$(official_net_env curl -4 -x "$CLAUDE_PROXY_URL" -vI --connect-timeout 8 --max-time 15 "https://${host}/" 2>&1 >/dev/null)"; then
-      if ! printf '%s\n' "$out" | grep -Eq "CONNECT ${host}:443|CONNECT tunnel established|CONNECT phase completed"; then
-        reason="${host} 没有走 ${CLAUDE_PROXY_URL} 的 HTTP CONNECT 隧道"
-      elif ! printf '%s\n' "$out" | grep -q 'SSL certificate verify ok'; then
-        reason="${host} 未显示证书验证通过"
-      else
-        issuer="$(printf '%s\n' "$out" | sed -n 's/.*issuer: //p' | head -1)"
-        if [ -z "$issuer" ]; then
-          reason="无法读取 ${host} 的证书 issuer"
-        else
-          case "$(printf '%s' "$issuer" | tr '[:upper:]' '[:lower:]')" in
-            *charles*|*mitm*|*fiddler*|*zscaler*|*clash*|*surge*|*proxy*)
-              reason="${host} 的证书 issuer 疑似代理/MITM: ${issuer}"
-              ;;
-            *)
-              ui_note 'TLS 预检通过：%s via %s issuer=%s' "$host" "$CLAUDE_PROXY_URL" "$issuer"
-              return 0
-              ;;
-          esac
-        fi
-      fi
-    else
+    out="$(official_net_env curl -4 -x "$CLAUDE_PROXY_URL" -vI --connect-timeout 8 --max-time 15 "https://${host}/" 2>&1 >/dev/null)" \
+      && curl_status=0 || curl_status=$?
+
+    # 后端识别必须先于退出码判定：Schannel 在证书校验失败时同样会以非零码退出，
+    # 那时报「无法连接或验证证书」会把一个平台限制说成网络或代理问题。
+    if tls_backend_lacks_cert_details "$out"; then
+      unsupported=1
+      reason="当前 curl 使用 Schannel（Windows 原生）TLS 后端，不输出证书验证结果和 issuer，无法对 ${host} 执行 TLS/MITM 校验。这是平台限制，不是代理或配置问题；解决办法见 README 的「平台支持」一节。"
+    elif [ "$curl_status" -ne 0 ]; then
       reason="无法连接或验证 ${host} 的证书"
+    elif ! printf '%s\n' "$out" | grep -Eq "CONNECT ${host}:443|CONNECT tunnel established|CONNECT phase completed"; then
+      reason="${host} 没有走 ${CLAUDE_PROXY_URL} 的 HTTP CONNECT 隧道"
+    elif ! printf '%s\n' "$out" | grep -q 'SSL certificate verify ok'; then
+      reason="${host} 未显示证书验证通过"
+    else
+      issuer="$(printf '%s\n' "$out" | sed -n 's/.*issuer: //p' | head -1)"
+      if [ -z "$issuer" ]; then
+        reason="无法读取 ${host} 的证书 issuer"
+      else
+        case "$(printf '%s' "$issuer" | tr '[:upper:]' '[:lower:]')" in
+          *charles*|*mitm*|*fiddler*|*zscaler*|*clash*|*surge*|*proxy*)
+            reason="${host} 的证书 issuer 疑似代理/MITM: ${issuer}"
+            ;;
+          *)
+            ui_note 'TLS 预检通过：%s via %s issuer=%s' "$host" "$CLAUDE_PROXY_URL" "$issuer"
+            return 0
+            ;;
+        esac
+      fi
     fi
+
+    # 平台不支持是确定性结果，重试只会浪费时间。
+    [ "$unsupported" -eq 0 ] || break
 
     if [ "$attempt" -lt "$TLS_CHECK_RETRIES" ]; then
       ui_warn 'TLS 预检重试：%s 第 %s/%s 次失败：%s' "$host" "$attempt" "$TLS_CHECK_RETRIES" "$reason"
@@ -787,18 +804,26 @@ check_tls_host() {
   done
 
   if [ "$mode" = "warn" ]; then
-    ui_warn 'TLS 预检警告：%s 经过 %s 次尝试仍未稳定通过：%s' "$host" "$TLS_CHECK_RETRIES" "$reason"
+    if [ "$unsupported" -eq 1 ]; then
+      ui_warn 'TLS 预检警告：%s' "$reason"
+    else
+      ui_warn 'TLS 预检警告：%s 经过 %s 次尝试仍未稳定通过：%s' "$host" "$TLS_CHECK_RETRIES" "$reason"
+    fi
     if [ "$UI_ENABLED" -eq 1 ]; then
-      out="$(printf '%s\n' "$out" | grep -Ei 'certificate|issuer|subject|SSL|error|CONNECT' || true)"
+      out="$(printf '%s\n' "$out" | grep -Ei 'certificate|issuer|subject|SSL|schannel|error|CONNECT' || true)"
       [ -z "$out" ] || ui_note '%s' "$out"
     else
-      printf '%s\n' "$out" | grep -Ei 'certificate|issuer|subject|SSL|error|CONNECT' >&2 || true
+      printf '%s\n' "$out" | grep -Ei 'certificate|issuer|subject|SSL|schannel|error|CONNECT' >&2 || true
     fi
     return 0
   fi
 
-  printf 'TLS 预检失败：%s 经过 %s 次尝试仍未通过：%s\n' "$host" "$TLS_CHECK_RETRIES" "$reason" >&2
-  printf '%s\n' "$out" | grep -Ei 'certificate|issuer|subject|SSL|error|CONNECT' >&2 || true
+  if [ "$unsupported" -eq 1 ]; then
+    printf 'TLS 预检失败：%s\n' "$reason" >&2
+  else
+    printf 'TLS 预检失败：%s 经过 %s 次尝试仍未通过：%s\n' "$host" "$TLS_CHECK_RETRIES" "$reason" >&2
+  fi
+  printf '%s\n' "$out" | grep -Ei 'certificate|issuer|subject|SSL|schannel|error|CONNECT' >&2 || true
   exit 7
 }
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 "$ROOT_DIR/tests/smoke.sh"
 "$ROOT_DIR/tests/ip_probe_format.sh"
+"$ROOT_DIR/tests/tls_backend_platform.sh"
 "$ROOT_DIR/tests/preflight_ui.sh"
 "$ROOT_DIR/tests/watchdog_state_machine.sh"
 "$ROOT_DIR/tests/watchdog_runtime.sh"

--- a/tests/tls_backend_platform.sh
+++ b/tests/tls_backend_platform.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Schannel（Windows 原生 TLS 后端）不打印证书验证结果和 issuer，TLS 预检无法执行。
+# 本用例要求：报错文案明确指出是平台不兼容，退出码仍是 7，不做无意义的重试，也不谎报
+# 尝试次数；curl 自身以非零码退出时同样要认出后端，而不是含糊地报「无法连接」。
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$TMP_DIR/home"
+
+# 直接复用仓库里的官方 settings 示例：生命周期策略升级时它会一起更新，fixture 不会过期。
+cp "$ROOT_DIR/config/official-settings-lifecycle.example.json" "$TMP_DIR/settings.json"
+
+printf 'fake ca\n' >"$TMP_DIR/cert.pem"
+printf '{"command":"/bin/echo","allowed_ips":["203.0.113.10"]}\n' >"$TMP_DIR/allowed.json"
+
+# $1 = 假 curl 在 TLS 探测上的退出码
+make_curl() {
+  local dir="$TMP_DIR/bin-$1"
+  mkdir -p "$dir"
+  cat >"$dir/curl" <<EOF
+#!/usr/bin/env bash
+args="\$*"
+printf '%s\n' "\$args" >>"\$HOME/curl.log"
+
+if printf '%s' "\$args" | grep -Eq '(^| )-6( |\$)'; then
+  exit 7
+fi
+
+if printf '%s' "\$args" | grep -q '/cdn-cgi/trace'; then
+  printf 'fl=1f2\n'
+  printf 'h=api.anthropic.com\n'
+  printf 'ip=203.0.113.10\n'
+  exit 0
+fi
+
+# Schannel 后端的 verbose 输出：隧道建好了，但没有 "SSL certificate verify ok"，
+# 也没有 issuer 行。
+if printf '%s' "\$args" | grep -q 'https://api.anthropic.com/'; then
+  {
+    printf '* CONNECT api.anthropic.com:443 HTTP/1.1\n'
+    printf '* CONNECT tunnel established, response 200\n'
+    printf '* schannel: disabled automatic use of client certificate\n'
+    printf '* Connection #0 to host 127.0.0.1:7897 left intact\n'
+  } >&2
+  exit $1
+fi
+
+exit 1
+EOF
+  chmod +x "$dir/curl"
+  printf '%s\n' "$dir"
+}
+
+run_precheck() {
+  (
+    cd "$TMP_DIR"
+    HOME="$TMP_DIR/home" \
+      USER="guard-test" \
+      PATH="$1:$PATH" \
+      LANG="en_US.UTF-8" \
+      CLAUDE_GUARD_CONFIG="$TMP_DIR/allowed.json" \
+      CLAUDE_GUARD_SETTINGS="$TMP_DIR/settings.json" \
+      CLAUDE_GUARD_CA_CERT="$TMP_DIR/cert.pem" \
+      CLAUDE_GUARD_IP_RETRIES=1 \
+      CLAUDE_GUARD_TLS_RETRIES=3 \
+      CLAUDE_GUARD_UI=never \
+      "$ROOT_DIR/bin/claude-guard" --precheck-only
+  )
+}
+
+# $1 = curl 退出码，$2 = 用例名
+assert_schannel_case() {
+  local code="$1" label="$2" bin out status attempts
+  bin="$(make_curl "$code")"
+  : >"$TMP_DIR/home/curl.log"
+  out="$TMP_DIR/out-$code"
+
+  set +e
+  run_precheck "$bin" >"$out" 2>&1
+  status=$?
+  set -e
+
+  if [ "$status" -ne 7 ]; then
+    printf '%s: returned %s instead of 7\n' "$label" "$status" >&2
+    cat "$out" >&2
+    exit 1
+  fi
+
+  # 报错必须指名平台不兼容，而不是含糊的「未显示证书验证通过」/「无法连接」——两者
+  # 读起来都像在指控用户被中间人劫持或代理坏了。
+  if ! grep -q 'Schannel' "$out"; then
+    printf '%s: failure must name the TLS backend\n' "$label" >&2
+    cat "$out" >&2
+    exit 1
+  fi
+  if grep -qE '未显示证书验证通过|无法连接或验证' "$out"; then
+    printf '%s: must not fall through to a generic TLS message\n' "$label" >&2
+    cat "$out" >&2
+    exit 1
+  fi
+
+  # 只探测了一次，就不能声称尝试了三次。
+  if grep -q '次尝试' "$out"; then
+    printf '%s: must not claim a retry count it did not spend\n' "$label" >&2
+    cat "$out" >&2
+    exit 1
+  fi
+
+  # 平台不支持是确定性结果：即使 TLS_CHECK_RETRIES=3，也只应探测一次。
+  attempts="$(grep -c 'https://api.anthropic.com/ *$' "$TMP_DIR/home/curl.log" || true)"
+  if [ "$attempts" -ne 1 ]; then
+    printf '%s: must not retry, got %s attempts\n' "$label" "$attempts" >&2
+    cat "$TMP_DIR/home/curl.log" >&2
+    exit 1
+  fi
+}
+
+# 1. Schannel，curl 自身成功退出（用户实际报告的形态）。
+assert_schannel_case 0 'schannel exit 0'
+
+# 2. Schannel，curl 因证书校验失败以 60 退出。后端识别必须先于退出码判定，否则会把
+#    平台限制说成网络或代理问题，并且白白重试三次。
+assert_schannel_case 60 'schannel exit 60'
+
+printf 'tls backend platform ok\n'


### PR DESCRIPTION
Closes #6。

Windows 原生 curl（Schannel 后端）跑不了 `check_tls_host`，但报错是「未显示证书验证通过」——读起来像在指控用户被中间人劫持，实际上是平台限制。

## 为什么不是放宽那行 grep

问题不在 `grep 'SSL certificate verify ok'`。紧接着还要从 curl 的 verbose 输出里 `sed` 出证书 `issuer:`，拿它匹配 Charles / Fiddler / Zscaler 这类 MITM 特征——**TLS 预检存在的理由就是这个检查**。Schannel 两样都不打印，所以放宽字符串匹配并不能恢复检查，只会把这一步变成什么都不查的空步骤。

因此这里选择明确报错，**不做静默降级**。

## 改了什么

- 新增 `tls_backend_lacks_cert_details`，从已有的 curl verbose 输出里识别 Schannel，不额外起进程。
- 把 curl 的输出和退出码分开保存，**后端识别先于退出码判定**。Schannel 在证书校验失败时同样以非零码退出，若先判退出码就会报「无法连接或验证证书」，把平台限制说成网络或代理问题，并且白白重试三次。
- 命中后写明确的 reason 并 `break`：平台不支持是确定性结果，重试三次纯属浪费。
- 既然只探测了一次，收尾文案就不能声称「经过 3 次尝试」。不支持的后端走独立文案，`warn` 模式同样处理。
- 失败时的证据转储加上 `schannel` 行，否则用户看不到判断依据。
- README 新增「平台支持」一节：macOS 已验证；Linux 预期可用但要自己设 `CLAUDE_GUARD_CA_CERT`（默认值 `/etc/ssl/cert.pem` 是 macOS 路径）；Windows 原生不支持，给出换 OpenSSL 版 curl 和 WSL2 两条绕行方案，各自的坑一并写清楚。

## 测试

新增 `tests/tls_backend_platform.sh`，覆盖 Schannel 在 curl 退出码 `0` 和 `60` 两种形态：断言退出码仍是 7、报错指名后端、不回落到含糊文案、不重试、不声称重试过。

fixture 直接复用 `config/official-settings-lifecycle.example.json`——那个文件本来就是生命周期策略的权威来源，策略升级时会一起更新，不会像手写副本那样过期。

四条反向验证都确实会挂：

```
去掉 schannel 分支        → schannel exit 0:  failure must name the TLS backend
退出码判定放回识别之前     → schannel exit 60: failure must name the TLS backend
去掉 break                → must not retry, got 3 attempts
恢复带次数的收尾文案       → must not claim a retry count it did not spend
```

`./scripts/check.sh` 全绿（10 个 fixture）。

## 与 #7 的关系

无先后依赖，两个方向都在本地 cherry-pick 模拟并跑过全套，都是 `exit 0` / 10 个 fixture 全绿。
