### PR TITLE
ci: 拆出独立 shellcheck 门禁，固定 v0.11.0 并校验官方产物摘要

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,3 +28,32 @@ jobs:
         run: /bin/bash --version | head -1
       - name: Run checks
         run: /bin/bash ./scripts/check.sh
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # 固定版本 + 校验官方产物摘要。不用 apt 的浮动版本，也不用未固定的第三方
+      # Action：ShellCheck 升级会带来新规则，浮动版本会让门禁在没人改代码的情况下
+      # 凭空变红，而未固定的 Action 等于把门禁的执行权交给别人的 tag。
+      - name: Install ShellCheck (pinned + checksum verified)
+        env:
+          SHELLCHECK_VERSION: v0.11.0
+          SHELLCHECK_SHA256: 8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
+        run: |
+          url="https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz"
+          curl -fsSL --retry 3 -o /tmp/shellcheck.tar.xz "$url"
+          echo "${SHELLCHECK_SHA256}  /tmp/shellcheck.tar.xz" | sha256sum -c -
+          tar -xJf /tmp/shellcheck.tar.xz -C /tmp
+          sudo install -m 0755 "/tmp/shellcheck-${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+      - name: Show ShellCheck version
+        run: shellcheck --version
+      - name: Run ShellCheck
+        run: |
+          # 覆盖全部受 Git 管理的 shell 文件，含两个无 .sh 后缀的入口
+          # bin/claude-guard 与 bin/claude-cc。
+          git ls-files 'bin/*' 'scripts/*.sh' 'tests/*.sh' | tee /tmp/sc-files.txt
+          # -S style 是最低严重级别，info 与 style 一并拦下——不留「先记着以后再说」
+          # 的空间；-x 跟随 source。豁免必须逐行写在源码里并注明理由，不做全局豁免。
+          # 走 xargs 保持参数边界，路径含空格时不失真。
+          xargs shellcheck -x -S style < /tmp/sc-files.txt

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -22,8 +22,8 @@ fi
 
 CLAUDE_GUARD_PREFIX="$TMP_DIR/prefix" "$ROOT_DIR/scripts/install-entrypoint-shims.sh" >/tmp/claude-guard-install.out 2>&1
 grep -q '入口已收敛' /tmp/claude-guard-install.out
-grep -q 'exec "'$TMP_DIR'/prefix/bin/claude-guard" "$@"' "$TMP_DIR/prefix/bin/claude"
-grep -q 'exec "'$TMP_DIR'/prefix/bin/claude-guard" "$@"' "$TMP_DIR/prefix/bin/claude-official"
+grep -q 'exec "'"$TMP_DIR"'/prefix/bin/claude-guard" "$@"' "$TMP_DIR/prefix/bin/claude"
+grep -q 'exec "'"$TMP_DIR"'/prefix/bin/claude-guard" "$@"' "$TMP_DIR/prefix/bin/claude-official"
 
 CLAUDE_GUARD_PREFIX="$TMP_DIR/cc-prefix" "$ROOT_DIR/scripts/install-cc-entrypoint.sh" >/tmp/claude-cc-install.out 2>&1
 grep -q 'CC Switch 入口' /tmp/claude-cc-install.out
@@ -42,6 +42,7 @@ if CLAUDE_GUARD_CONFIG="$TMP_DIR/relative-command.json" "$ROOT_DIR/bin/claude-gu
 fi
 grep -q '必须是原始 Claude CLI 的绝对路径' /tmp/claude-guard-test.out
 
+# shellcheck disable=SC2016  # 指纹 fixture 必须写入字面量 ${n} / ${r}，展开后就不再是被检测的那段内容
 printf '#!/usr/bin/env bash\n# Asia/Shanghai\n# Asia/Urumqi\n# Today${n}s date is ${r}.\nprintf fake-claude\\n\n' > "$TMP_DIR/fingerprint-claude"
 chmod +x "$TMP_DIR/fingerprint-claude"
 printf '{"command":"%s","allowed_ips":["1.2.3.4"]}\n' "$TMP_DIR/fingerprint-claude" > "$TMP_DIR/fingerprint-config.json"
@@ -89,6 +90,7 @@ grep -q 'strict 模式拒绝启动' /tmp/claude-guard-test.out
 
 mkdir -p "$TMP_DIR/npm/@anthropic-ai/claude-code/bin" "$TMP_DIR/npm/@anthropic-ai/claude-code-darwin-arm64"
 printf '#!/usr/bin/env bash\nprintf wrapper\\n\n' > "$TMP_DIR/npm/@anthropic-ai/claude-code/bin/claude.exe"
+# shellcheck disable=SC2016  # 指纹 fixture 必须写入字面量 ${n} / ${r}，展开后就不再是被检测的那段内容
 printf '#!/usr/bin/env bash\n# Asia/Shanghai\n# Asia/Urumqi\n# Today${n}s date is ${r}.\nprintf platform\\n\n' > "$TMP_DIR/npm/@anthropic-ai/claude-code-darwin-arm64/claude"
 chmod +x "$TMP_DIR/npm/@anthropic-ai/claude-code/bin/claude.exe" "$TMP_DIR/npm/@anthropic-ai/claude-code-darwin-arm64/claude"
 printf '{"command":"%s","allowed_ips":["1.2.3.4"]}\n' "$TMP_DIR/npm/@anthropic-ai/claude-code/bin/claude.exe" > "$TMP_DIR/wrapper-config.json"


### PR DESCRIPTION
Closes #14

## 问题

那个 job 叫 `shell-checks`，但它不跑 ShellCheck——执行的是 `scripts/check.sh`，里面是 `bash -n` 加各测试脚本。ShellCheck 此前只是一道**人工、不成文、不阻断**的工序：源码里有 `# shellcheck disable=` 的 pragma，`docs/v2.0.2-preflight-ui.md:99` 与 `docs/v2.0.3-watchdog-observability.md:112` 里有手敲的命令，但它从来不是合并门禁。

（job 名在上一个 PR 已随矩阵改为 `tests`，本 PR 补上真正的 `shellcheck`。）

## 怎么做的

**固定版本 + 校验官方产物摘要。**

```
SHELLCHECK_VERSION: v0.11.0
SHELLCHECK_SHA256:  8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
```

摘要取自 koalaman/shellcheck 官方 release 的 `shellcheck-v0.11.0.linux.x86_64.tar.xz`，独立下载两次比对一致。安装步骤 `sha256sum -c -` 校验后才解包。

不用 apt 的浮动版本：ShellCheck 升级会带来新规则，浮动版本会让门禁**在没人改代码的情况下凭空变红**。也不用未固定的第三方 Action：那等于把门禁的执行权交给别人的 tag。

**job 名固定为 `shellcheck`，非矩阵，先打印实际版本存档。**

**扫描范围用 `git ls-files` 枚举**，覆盖 `bin/*`、`scripts/*.sh`、`tests/*.sh` 共 18 个文件，**含两个无 `.sh` 后缀的入口** `bin/claude-guard` 与 `bin/claude-cc`。走 `xargs` 保参数边界。

**`-S style` 是最低严重级别**，info 与 style 一并拦下，不留「先记着以后再说」的空间；`-x` 跟随 source。

## 清掉现存的 4 条

全在 `tests/smoke.sh`：

| 位置 | 规则 | 处理 |
| --- | --- | --- |
| 25, 26 | SC2086 | **修复**。`$TMP_DIR` 加引号——路径含空格时断言才不会失真 |
| 45, 92 | SC2016 | **逐行 disable 并注明理由**。指纹 fixture 必须写入字面量 `${n}` / `${r}`，展开后就不再是被检测的那段内容 |

不做全局豁免，也不用 `.shellcheckrc` 关规则——豁免必须写在它适用的那一行上，并说明为什么。

## 验证（macOS bash 3.2.57）

- `shellcheck -x -S style` 扫全部 18 个文件 → clean
- `/bin/bash ./scripts/check.sh` → exit 0
- **门禁有效性**：临时往 `scripts/install.sh` 追加 `ls | grep claude` → `SC2010 (warning)` 变红；复原后回绿

关于最后一条，第一次探针用的是 `BAD=1; echo $BAD`，**没有变红**——ShellCheck 能证明该变量是常量，不报 SC2086。这不是门禁失效，是探针本身不成立。换成 `ls | grep` 后如期变红。记在这里，免得以后有人用同样的方式误判门禁。

## 合并前

三项 check（`tests (ubuntu-latest)` / `tests (macos-latest)` / `shellcheck`）全绿后，先把 `shellcheck` 追加进 `main protection` ruleset 的 required checks 并回读确认其他字段未变，再合并。
